### PR TITLE
Add custom route for enabling webhook functionality

### DIFF
--- a/api/webhooks/config/routes.json
+++ b/api/webhooks/config/routes.json
@@ -1,0 +1,12 @@
+{
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/update-content",
+      "handler": "webhooks.updateContent",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/webhooks/controllers/webhooks.js
+++ b/api/webhooks/controllers/webhooks.js
@@ -1,0 +1,37 @@
+'use strict';
+const https = require('https')
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {
+  async updateContent(ctx) {
+    console.log("test")
+    const options = {
+      hostname: 'api.github.com',
+      port: 443,
+      path: '/repos/cds-snc/cds-website-pr-bot/dispatches',
+      method: 'POST',
+      headers: {
+        'Accept': 'application/vnd.github.v3+json'
+      }
+    }
+    const body = JSON.stringify({
+      "event_type": "strapi_update"
+    });
+    
+    const req = https.request(options, res => {
+      console.log(`statusCode: ${res.statusCode}`)
+    
+      res.on('data', d => {
+        process.stdout.write(d)
+      })
+    })
+    req.on('error', error => {
+      console.error(error)
+    })
+    req.end(body)
+  }
+};


### PR DESCRIPTION
Essentially, we use strapi's built in webhook functionality to call this new route, which performs the actual call to the github API to call the PR-bot. We need to do it this way to satisfy github's request requirements, as the strapi webhook feature doesn't support a request body.