### PR TITLE
[WIP] added job categories

### DIFF
--- a/api/job-posting-en/models/job-posting-en.settings.json
+++ b/api/job-posting-en/models/job-posting-en.settings.json
@@ -11,6 +11,21 @@
     "draftAndPublish": true
   },
   "attributes": {
+    "Category": {
+      "type": "enumeration",
+      "enum": [
+        "Leadership",
+        "Design",
+        "Research",
+        "Development",
+        "Internal Operations",
+        "Partnerships",
+        "Policy",
+        "Product Management",
+        "Outreach",
+        "People and Culture"
+      ]
+    },
     "Title": {
       "type": "string",
       "required": true

--- a/api/job-posting-fr/models/job-posting-fr.settings.json
+++ b/api/job-posting-fr/models/job-posting-fr.settings.json
@@ -11,6 +11,21 @@
     "draftAndPublish": true
   },
   "attributes": {
+    "Category": {
+      "type": "enumeration",
+      "enum": [
+        "Équipe de la direction",
+        "Conception",
+        "Recherche",
+        "Développement",
+        "Opérations internes",
+        "Partenariats",
+        "Politiques",
+        "Gestion de produits",
+        "Liaison et diffusion",
+        "Personnel et culture"
+      ]
+    },
     "Title": {
       "type": "string"
     },


### PR DESCRIPTION
# Summary | Résumé

GitHub Issue: https://github.com/cds-snc/digital-canada-ca/issues/2462

Adding a job category drop down for the new career page redesign so job postings can be organized into categories

Waiting on final designs before merge