### PR TITLE
feat: setup a base version of the catalog metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     github.com/project-slug: cds-snc/cds-website-cms
   links:
-    - url: tbc
+    - url: https://strapi.cdssandbox.xyz/admin/
 spec:
   type: website
   owner: group:cds-snc/website-devs

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cds-website-cms
+  description: A Strapi instance serving as the content management system for the CDS website - Une instance de Strapi servant de gestionnaire de contenu pour le site web du SNC
+  annotations:
+    github.com/project-slug: cds-snc/cds-website-cms
+  links:
+    - url: tbc
+spec:
+  type: website
+  owner: group:cds-snc/website-devs
+  lifecycle: production
+  system: digital-canada-website


### PR DESCRIPTION
# Summary | Résumé

Create a initial version of the catalog-info.yaml file to provision this component in the Backstage instance.

- Specific element to review on line 9: links are optional, they can be used to point to the website component but can also be removed altogether if we do not want to log this here.