### PR TITLE
fix: update the cds website system name to match metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,4 +11,4 @@ spec:
   type: website
   owner: group:cds-snc/website-devs
   lifecycle: production
-  system: digital-canada-website
+  system: cds-website


### PR DESCRIPTION
# Summary | Résumé

Updating the name of the CDS's website system to match the upcoming system definition and alleviate the duplication of the component of the name.