### PR TITLE
removed lever id, added draft for job postings

### DIFF
--- a/api/job-posting-en/models/job-posting-en.settings.json
+++ b/api/job-posting-en/models/job-posting-en.settings.json
@@ -19,9 +19,6 @@
       "type": "text",
       "required": true
     },
-    "LeverId": {
-      "type": "string"
-    },
     "LinkHidden": {
       "type": "boolean",
       "default": false
@@ -33,6 +30,10 @@
     "TranslationID": {
       "type": "string",
       "required": true
+    },
+    "Draft": {
+      "type": "boolean",
+      "default": false
     },
     "Body": {
       "type": "richtext"

--- a/api/job-posting-fr/models/job-posting-fr.settings.json
+++ b/api/job-posting-fr/models/job-posting-fr.settings.json
@@ -17,9 +17,6 @@
     "Description": {
       "type": "text"
     },
-    "LeverId": {
-      "type": "string"
-    },
     "TranslationID": {
       "type": "string"
     },
@@ -28,6 +25,10 @@
       "default": false
     },
     "FormHidden": {
+      "type": "boolean",
+      "default": false
+    },
+    "Draft": {
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
# Summary | Résumé

Removed Lever ID since it is no longer in use. Added draft to the job posting so once the posting becomes inactive, the link is no longer active and will take users to the 404 page